### PR TITLE
Add prepare step

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "prepare": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [


### PR DESCRIPTION
Adding a `prepare` script allows easy installation as a `git` dependency. It also makes `npm publish` easier since you don't need to build first.